### PR TITLE
print cost per mile

### DIFF
--- a/wise/cost.py
+++ b/wise/cost.py
@@ -5,7 +5,50 @@ from tabulate import tabulate
 from .price import Price
 
 
-def print_costs(
+def print_costs(prices: list[Price], card_fee_percent: float = 1.5, reward_rate: float = 0.1) -> None:
+    table = []
+    for price in prices:
+        card_fee = price.source_amount * card_fee_percent / 100
+        wise_fee_percent = 100 * price.total / price.source_amount
+        fee = card_fee + price.total
+        fee_percent = 100 * fee / (price.source_amount + card_fee)
+        cost_per_mile = fee / (price.source_amount * reward_rate)
+
+        table.append(
+            [
+                # f"{price.price_set_id}",
+                f"{price.source_amount:.2f} {price.source_currency}",
+                f"{price.target_amount:.2f} {price.target_currency}",
+                # f"{price.pay_in_method}",
+                # f"{price.pay_out_method}",
+                f"{price.mid_rate:.4f}",
+                f"{price.total:.2f} {price.source_currency} ({wise_fee_percent:.2f}%)",
+                f"{fee:.2f} {price.source_currency} ({fee_percent:.2f}%)",
+                f"{cost_per_mile:.4f}",
+            ]
+        )
+
+    print(
+        tabulate(
+            table,
+            headers=[
+                # "Price Set ID",
+                "Source",
+                "Target",
+                # "Pay In Method",
+                # "Pay Out Method",
+                "Mid Rate",
+                "Wise Fee",
+                "Total Fee",
+                "Cost per Mile",
+            ],
+            tablefmt="rounded_grid",
+            stralign="right",
+        )
+    )
+
+
+def print_cash_back_costs(
     prices: list[Price],
     card_fee_percent: float = 1.5,
     # reward_rate: float = 0.1,


### PR DESCRIPTION
This pull request includes significant updates to the `print_costs` function in `wise/cost.py` to enhance its functionality and output format. The changes include adding new parameters, calculating additional metrics, and improving the table display.

Enhancements to `print_costs` function:

* [`wise/cost.py`](diffhunk://#diff-41b90a44e40282a9ee7ff9426b9e82fcd8043ab7c25c186b4bc97856cff325f9L8-R51): Updated the `print_costs` function to accept `prices`, `card_fee_percent`, and `reward_rate` as parameters. The function now calculates `card_fee`, `wise_fee_percent`, `fee`, `fee_percent`, and `cost_per_mile` for each price and appends these details to a table. The table is then printed using the `tabulate` library with a formatted header.